### PR TITLE
Show IP address on Unicorn Hat

### DIFF
--- a/examples/show_my_ip.service
+++ b/examples/show_my_ip.service
@@ -1,9 +1,0 @@
- [Unit]
- Description=display IP on the unicorn HD hat
-
- [Service]
- Type=idle
- ExecStart=/usr/bin/python3 /home/pi/Pimoroni/unicornhathd/examples/show_my_ip.py
-
- [Install]
- WantedBy=multi-user.target

--- a/examples/show_my_ip/README.md
+++ b/examples/show_my_ip/README.md
@@ -1,0 +1,12 @@
+# Show My Ip 
+
+This is a useful service that will display your current IP address (from your Wifi connection, and not your Ethernet port) every 10 seconds. 
+
+To install it run:
+
+`sh ip_at_boot.sh`
+
+This will install the appropriate service for you.
+
+Caveat:
+this is a simple implementation that requires an internet connection to figure out the IP address. If you are connecting to a router that does not provide an internet connection, it will not work.

--- a/examples/show_my_ip/README.md
+++ b/examples/show_my_ip/README.md
@@ -1,6 +1,6 @@
 # Show My Ip 
 
-This is a useful service that will display your current IP address (from your Wifi connection, and not your Ethernet port) every 10 seconds. 
+This is a useful service that will display your current IP address (either from your Wifi connection, or your Ethernet port) every 10 seconds. 
 
 To install it run:
 

--- a/examples/show_my_ip/ip_at_boot.sh
+++ b/examples/show_my_ip/ip_at_boot.sh
@@ -1,0 +1,3 @@
+sudo cp show_my_ip.service /etc/systemd/system/
+sudo systemctl enable show_my_ip.service
+sudo systemctl start show_my_ip.service

--- a/examples/show_my_ip/show_my_ip.py
+++ b/examples/show_my_ip/show_my_ip.py
@@ -32,10 +32,11 @@ def create_image_from_text(in_text):
     image = Image.new("RGB", (text_width, text_height), (0,0,0))
     draw = ImageDraw.Draw(image)
     draw.text((text_x, text_y), my_ip, colours, font=font)
-    return image, text_width
+    return (image, text_width)
+
 
 # DISPLAY
-def scroll_txt((image,text_width)):
+def scroll_txt(image, text_width ):
     unicornhathd.rotation(0)
     for scroll in range(text_width - width):
         for x in range(width):
@@ -50,15 +51,13 @@ def scroll_txt((image,text_width)):
 
 # one stop call for scrolling text
 def scroll_text(in_txt):
-    scroll_txt(create_image_from_text(in_txt))
+    image, text_width = create_image_from_text(in_txt)
+    scroll_txt(image, text_width)
 
-width, height = unicornhathd.get_shape()  # 16,16 by default
-my_ip = get_ip()
-# my_image, text_width = create_image_from_text(my_ip)
-# scroll_txt(my_image,text_width)
-scroll_text(my_ip)
+if __name__ == "__main__":
 
 
+    width, height = unicornhathd.get_shape()  # 16,16 by default
+    my_ip = get_ip()
 
-
-
+    scroll_text(my_ip)

--- a/examples/show_my_ip/show_my_ip.service
+++ b/examples/show_my_ip/show_my_ip.service
@@ -1,0 +1,11 @@
+ [Unit]
+ Description=display IP on the unicorn HD hat
+
+ [Service]
+ Type=idle
+ ExecStart=/usr/bin/python3 /home/pi/Pimoroni/unicornhathd/examples/show_my_ip/show_my_ip.py
+ Restart=always
+ RestartSec=10
+
+ [Install]
+ WantedBy=multi-user.target


### PR DESCRIPTION
If, like me, you keep forgetting which IP address your headless Pi is on, this can be a useful tool.

It will scroll the IP address across the unicorn HAT every 10 seconds via a systemd service.

