### PR TITLE
Added tuples and strings to set_pixel()

### DIFF
--- a/library/unicornhathd/__init__.py
+++ b/library/unicornhathd/__init__.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 """Unicorn HAT HD library.
 
 Drive the 16x16 RGB pixel Pimoronu Unicorn HAT HD

--- a/library/unicornhathd/__init__.py
+++ b/library/unicornhathd/__init__.py
@@ -224,15 +224,15 @@ def set_pixel(x, y, r, g=None, b=None):
 
     """
     if type(r) is tuple:
-        r, g, b = r
-
+        r, g, b = r
+        
     elif type(r) is str:
         try:
             r, g, b = COLORS[r.lower()]
-
+            
         except KeyError:
             raise ValueError('Invalid color!')
-
+            
     _buf[int(x)][int(y)] = r, g, b
 
 


### PR DESCRIPTION
Copied over the COLORS array and added the check for (r,g,b) as a tuple or as a string like 'red' from the unicornhat source.

**Reasoning:**
My classroom has standard HAT units (8x8) and HD units (16x16). Some students could use tuples, others couldn't. This seemed silly, so I'm trying my first **ever** Guthub pull request on a public repo.